### PR TITLE
Add language and color options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ require 'build' {
     project = nil,
     map = 'map.w3x',
     src = 'src',
-    run = nil
+    run = nil,
+	options = {
+		language = "ru",
+		consoleColor = true,
+	}
 }
 ```
 ### Параметры сборки
@@ -121,6 +125,21 @@ require 'build' {
 }
 ```
 После сборки открывает карту в редакторе `editor` или в игре `game`. По умолчанию не делает ничего.
+
+
+#### `options`
+```lua
+require 'build' {
+	options = {
+		language = "ru",
+		consoleColor = true,
+	}
+}
+```
+Таблица содержит настройки программы сборки. Можно переключить язык или выключить цвета в консоли.
+
+- `language` = "en"/"ru"
+- `consoleColor` = true/false
 
 ### Примечания
 - Устанавливайте файлам `.lua` режим переноса строки `CRLF`. 

--- a/lua/build.lua
+++ b/lua/build.lua
@@ -16,7 +16,7 @@ setmetatable(tr, {
 		-- Lookup translation if exists
 		local requested = tbl[locale] and tbl[locale][key]
 		if not requested then
-			-- default to RU/EN
+			-- default to EN/RU
 			requested = tbl.en[key] or tbl.ru[key]
 		end
 		return requested
@@ -158,6 +158,43 @@ end
 print(help('cheapack') .. ' ' .. color.blue .. version .. color.reset)
 
 return function(param)
+	-- param
+	param = param or {}
+	if type(param) ~= 'table' then param = { param } end
+	param.map      = param.map or 'map.w3x'
+	param.src      = param.src or 'src'
+	param.reforged = not not param.reforged
+	
+	-- set options
+	do
+		-- defaults: preserve old behavior for now
+		local optionsDefault = {
+			language = "ru",
+			consoleColor = true
+		}
+		if param.options then
+			-- add missing options to user-supplied table
+			for k, default in pairs(optionsDefault) do
+				if param.options[k] == nil then
+					param.options[k] = default
+				end
+			end
+		else
+			param.options = optionsDefault
+		end
+		
+		-- apply language
+		tr._lang = param.options.language
+		
+		-- apply colors
+		if param.options.consoleColor == false then
+			for name, _ in pairs(color) do
+				-- make all no-op
+				color[name] = ""
+			end
+		end
+	end
+	
 	-- check process
 	if isProcessRun(editorExe) then
 		return log(color.red .. tr'ERROR_EDITOR_OPEN' .. '\n' .. color.yellow .. editorExe .. color.reset)
@@ -165,13 +202,6 @@ return function(param)
 	if isProcessRun(gameExe) then
 		return log(color.red .. tr'ERROR_GAME_OPEN' .. '\n' .. color.yellow .. gameExe .. color.reset)
 	end
-
-	-- param
-	param = param or {}
-	if type(param) ~= 'table' then param = { param } end
-	param.map      = param.map or 'map.w3x'
-	param.src      = param.src or 'src'
-	param.reforged = not not param.reforged
 
 	-- param: project
 	if param.project == nil then


### PR DESCRIPTION
closes #5 

> Build: Add options support for language and color
> Options can be set as part of the build script:
    ...
    src = {"myscript.lua"}
    options = {
       language = "en",
       consoleColor = false,
    }
    ...

See readme for usage. I don't know what to do with the declination on line 258, left the Russian text there for now. Refactoring? "Later"

Everything is 100% backwards-compatible for now and old behavior left unchanged (Russian+color)